### PR TITLE
Adds pin to the wr_freq_res function in the header file

### DIFF
--- a/src/pwmWrite.h
+++ b/src/pwmWrite.h
@@ -121,7 +121,7 @@ class Pwm {
     void wr_servo(int pin, float value, double speed, double ke);
     void wr_ch_pair(int ch, uint32_t frequency, uint8_t resolution);
     void wr_duty(int ch, uint32_t duty);
-    void wr_freq_res(int ch, uint32_t frequency, uint8_t resolution);
+    void wr_freq_res(int ch, uint32_t frequency, uint8_t resolution, int pin);
     void wr_phase(int ch, uint32_t duty, uint32_t phase);
     void reset_fields(int ch);
     bool sync = false;


### PR DESCRIPTION
This adds the missing `pin` parameter in the `wr_freq_res` function in the `pwmWrite.h` file.

With this change, I could upload to an esp32 using the esp arduino 3.0 platform.